### PR TITLE
FEAT: !!dirty !!time commands

### DIFF
--- a/src/command_handler.ts
+++ b/src/command_handler.ts
@@ -15,6 +15,8 @@ import {RotationHelpCommand} from "./commands/rotation-help";
 import {BugTemplateCommand} from "./commands/bugtemplate";
 import {OpenExternalCommand} from "./commands/opendesktop";
 import {TimezonesCommand} from "./commands/timezones";
+import { DirtyInstallCommand } from "./commands/dirty";
+import { FixTimeCommand } from "./commands/time";
 
 /** Handler for bot commands issued by users. */
 export class CommandHandler {
@@ -34,7 +36,10 @@ export class CommandHandler {
             RotationHelpCommand,
             BugTemplateCommand,
             OpenExternalCommand,
+            DirtyInstallCommand,
+            FixTimeCommand,
             TimezonesCommand
+            
         ];
 
         this.commands = commandClasses.map(commandClass => new commandClass());

--- a/src/commands/dirty.ts
+++ b/src/commands/dirty.ts
@@ -1,0 +1,21 @@
+import {Command} from "./command";
+import {CommandContext} from "../models/command_context";
+
+export class DirtyInstallCommand implements Command {
+    commandNames = ["dirtyinstall", "cleanreinstall"];
+
+    constructor() {
+    }
+
+    getHelpMessage(commandPrefix: string): string {
+        return `Use ${commandPrefix}dirtyinstall to receive steps to clean up a dirty teamcraft installation.`;
+    }
+
+    async run(parsedUserCommand: CommandContext): Promise<void> {
+        await parsedUserCommand.originalMessage.channel.send("You likely have a dirty install laying around please do the following to fully ensure TC is closed and removed before reinstalling. \n```- Open task manager and end all teamcraft processes\n- Navigate to your appdata folder it is going to be the following path replaced with your windows username C:\\Users\\USERNAME\\AppData\n- Navigate into the roaming folder and please delete the ffxiv-teamcraft folder.\n- Go back to appdata and navigate to the local/Programs folder and delete ffxiv-teamcraft.\n- Please open Control Panel\\Programs\\Programs and Features and make sure teamcraft is not listed in the list of installed programs if it is please click it and click uninstall it will fuss and say that the app cannot be\n  found, just click yes and it should remove it from the list.\n- Restart your computer, this is just in case a lingering instance is holding on to the port TC uses its weird I couldn't tell you why it happens it just does and a restart will fix it.\n- Install Teamcraft from https://ffxivteamcraft.com/desktop```");
+    }
+
+    hasPermissionToRun(parsedUserCommand: CommandContext): boolean {
+        return true;
+    }
+}

--- a/src/commands/time.ts
+++ b/src/commands/time.ts
@@ -1,0 +1,21 @@
+import {Command} from "./command";
+import {CommandContext} from "../models/command_context";
+
+export class FixTimeCommand implements Command {
+    commandNames = ["time", "alarmclock"];
+
+    constructor() {
+    }
+
+    getHelpMessage(commandPrefix: string): string {
+        return `Use ${commandPrefix}time to get information on how to fix incorrect alarm times`;
+    }
+
+    async run(parsedUserCommand: CommandContext): Promise<void> {
+        await parsedUserCommand.originalMessage.channel.send("If you are having issues with timed node alarms being early or late then your computers clock may be off! Check https://time.is/ to see how off your windows clock is. \nYou can just disable and re-enable windows auto time sync and it will fix itself.");
+    }
+
+    hasPermissionToRun(parsedUserCommand: CommandContext): boolean {
+        return true;
+    }
+}


### PR DESCRIPTION
Added two commands to make life easier.

!!dirty - will outline steps to repair a dirty install which can fix the address in use errors when TC isn't closed properly as well as numerous other things, this is a last resort for users since it has several steps involved but is basically guaranteed to be a silver bullet and fix most of their issues that aren't actually bugs.

!!time - will outline the steps to fix timed node alarms being delayed or popping too soon. This command could probably be renamed but this is short and easy and relevant.