### PR TITLE
Backslash fixes, simplified Console command, tweaks

### DIFF
--- a/src/commands/antivirus.ts
+++ b/src/commands/antivirus.ts
@@ -16,9 +16,9 @@ export class AntivirusCommand implements Command {
         const embed = new MessageEmbed()
         .setTitle("MachinaWrapper is likely getting blocked by your antivirus")
         .setDescription("Many antivirus programs might attempt to block MachinaWrapper (needed for packet capture), or even the entire Teamcraft app installer, out of an abundance of caution.")
-        .addField("Please try excluding the entire Teamcraft install folder, especially the MachinaWrapper folder (and/or the files ``MachinaWrapper.exe``, ``Machina.dll``, and ``Machina.FFXIV.dll``), in your antivirus.", "MachinaWrapper should be located at ``%LocalAppData%\\ffxiv-teamcraft\\app-x.y.z\\resources\MachinaWrapper\\`` (where x.y.z is the latest version number).")
+        .addField("Please try excluding the entire Teamcraft install folder, especially the MachinaWrapper folder (and/or the files ``MachinaWrapper.exe``, ``Machina.dll``, and ``Machina.FFXIV.dll``), in your antivirus.", "MachinaWrapper should be located at ``%LocalAppData%\\ffxiv-teamcraft\\app-x.y.z\\resources\\MachinaWrapper\\`` (where ``x.y.z`` is actually the latest version number for Teamcraft).")
 		.addField("Another option to try if the above has not fixed it:", "You may also wish to right-click and check the Properties of the EXE and DLL files in the folder to make sure Windows itself isn't showing an \"Unblock\" button near the bottom that you may click to unblock the file.")
-		.addField("This may have caused the download of your installer to become corrupted.", "If you suspect that any part of the Teamcraft app may not have been installed properly due to the blocking, please re-download and re-install Teamcraft.")
+		.addField("This may have caused the download or installation of your installer to become corrupted", "Since it is likely that the Teamcraft app may not have been installed properly due to this blocking, please re-download and re-install Teamcraft to ensure all components have been installed properly.")
 		
         .setFooter(
           "ffxiv-teamcraft",

--- a/src/commands/bug.ts
+++ b/src/commands/bug.ts
@@ -15,12 +15,13 @@ export class BugCommand implements Command {
     async run(parsedUserCommand: CommandContext): Promise<void> {
         const embed = new MessageEmbed()
         .setTitle("How to submit a bug report for Teamcraft")
-        .setDescription("A clear and concise description of what the bug is.")
-        .addField("Steps to reproduce!", "A bug that can't be reproduced can't be fixed. Explain in detail what needs to be done to create the bug you are experiencing.")
-        .addField("Expected Behavior!", "A clear and concise description of what you expected to happen.")
-        .addField("Screenshots!", "Please provide any screenshots you can of what is happening. Opening the console via CTRL + SHIFT + I and clicking the console tab can also help us diagnose the issue.")
-        .addField("Software Version/Type!", "Are you using the website or the desktop app? If the app then what version? If the website then what browser?")
-        .addField("Additional Information", "Any additional context can help diagnose the issue. The more info the better!")
+        .setDescription("Providing a thorough bug or problem report helps us solve your issues quickly!")
+		.addField("Issue:", "A clear and concise description of what the bug is.")
+        .addField("Steps to reproduce:", "A bug that can't be reproduced can't be fixed. Explain in detail, with numbered steps, what needs to be done to trigger the issue or bug you are experiencing.")
+        .addField("Expected Behavior:", "A clear and concise description of what you expected to happen.")
+        .addField("Screenshots:", "Please provide any screenshots you can of what is happening. Opening the console via CTRL + SHIFT + I and clicking the ``Console`` tab is often extremely useful to help us diagnose the issue. Discord allows you to attach multiple screenshots to one post if need be!")
+        .addField("Software Version/Type:", "Are you using the website or the desktop app? If the app, then which version? If the website, then which browser?")
+        .addField("Additional Information:", "Any additional context that can help diagnose the issue. The more info, the better!")
         .addField("Bug Template", "```**Issue:** \n> \n**Steps to Reproduce:**\n> \n**Expected Behaviour:**\n> \n**Teamcraft Version - Browser / Desktop Client**\n> \n**Additional Information:**\n> \n**Screenshots:**\n\nCopy this and fill next to the > ```")
         .setFooter(
           "ffxiv-teamcraft",

--- a/src/commands/bugtemplate.ts
+++ b/src/commands/bugtemplate.ts
@@ -9,13 +9,13 @@ export class BugTemplateCommand implements Command {
     }
 
     getHelpMessage(commandPrefix: string): string {
-        return `Use ${commandPrefix}bug to get information on how to submit a bug report`;
+        return `Use ${commandPrefix}bug to get information on how to submit a bug report.`;
     }
 
     async run(parsedUserCommand: CommandContext): Promise<void> {
         const embed = new MessageEmbed()
         .setTitle("Bug Report Template")
-        .setDescription("```**Issue:** \n> \n**Steps to Reproduce:**\n> \n**Expected Behaviour:**\n> \n**Teamcraft Version - Browser / Desktop Client**\n> \n**Additional Information:**\n> \n**Screenshots:**\n\nCopy this and fill next to the > ```")
+        .setDescription("```**Issue:** \n A clear and concise description of what the bug is. \n> \n**Steps to Reproduce:** \n A bug that can't be reproduced can't be fixed. Explain in detail, with numbered steps, what needs to be done to create the bug you are experiencing. \n> \n**Expected Behaviour:** \n A clear and concise description of what you expected to happen. \n> \n**Teamcraft Version - Browser / Desktop Client** \n Are you using the website or the desktop app? If the app, then which version? If the website, then which browser? \n> \n**Additional Information:** \n Any additional context that may help diagnose the issue. The more info, the better! \n> \n**Screenshots (Discord lets you attach multiple if need be):**\n\nCopy this template and fill next to the > ```")
         .setFooter(
           "ffxiv-teamcraft",
           "https://ffxivteamcraft.com/assets/logo.png"

--- a/src/commands/console.ts
+++ b/src/commands/console.ts
@@ -14,11 +14,10 @@ export class ConsoleCommand implements Command {
 
     async run(parsedUserCommand: CommandContext): Promise<void> {
         const embed = new MessageEmbed()
-        .setTitle("How to open the console")
-        .setDescription("Please open the console and take a screenshot of it to post in <#639503745176174592>.")
-        .addField("Website", "Please press F12 on the keyboard and click the ``Console`` tab.")
-        .addField("Desktop App", "Please navigate to your Profile > Settings > Desktop > Open Dev Tools and click the ``Console`` tab.")
-        .addField("I can't get to my profile. How am I supposed to get to the console?", "``CTRL + SHIFT + I`` will also open the dev tools, allowing you to still get to the console if the app is not doing anything.")
+        .setTitle("How to open the console to take a screenshot")
+        .setDescription("Please open the console and **take a screenshot** of it to post in <#639503745176174592>. You may find it useful to type \"Teamcraft\" in the Filter bar at the very top, to restrict the console so that errors from ads and such are filtered out!")
+        .addField("Desktop App only", "You may navigate to your Profile in the upper-right > Settings > Desktop > Open Dev Tools and click the ``Console`` tab.")
+        .addField("Desktop App or Website", "Please press ``CTRL + SHIFT + I`` (or ``Command + SHIFT + I`` on Mac) on the keyboard, and click the ``Console`` tab.")
         .setFooter(
           "ffxiv-teamcraft",
           "https://ffxivteamcraft.com/assets/logo.png"

--- a/src/commands/powershell.ts
+++ b/src/commands/powershell.ts
@@ -17,7 +17,7 @@ export class PowershellCommand implements Command {
         .setTitle("Teamcraft doesn't think Npcap is installed")
         .setDescription("Ensure that Powershell is added to your PATH variable")
         .addField("Update Powershell", "First, make sure Powershell is fully updated: <https://docs.microsoft.com/en-us/powershell/scripting/windows-powershell/install/installing-windows-powershell>")
-		.addField("Ensure that Powershell has been added to your PATH Variable:","1. Press the Windows key, search \"env\" and hit enter \n 2. Click \"Environment Variables\" in the advanced tab \n 3. Under \"**System Variables**\", locate the Path entry \n 4. Click \"New\" and paste `%SystemRoot%\system32\WindowsPowerShell\v1.0` \n 5. Click OK to confirm all this work, then try reopening TC and/or reinstalling Npcap!")
+		.addField("Ensure that Powershell has been added to your PATH Variable:","1. Press the Windows key, search \"env\" and hit enter \n 2. Click \"Environment Variables\" in the advanced tab \n 3. Under \"**System Variables**\", locate the Path entry \n 4. Click \"New\" and paste `%SystemRoot%\\system32\\WindowsPowerShell\\v1.0` \n 5. Click OK to confirm all this work, then try reopening TC and/or reinstalling Npcap!")
         .setFooter(
           "ffxiv-teamcraft",
           "https://ffxivteamcraft.com/assets/logo.png"

--- a/src/commands/vpn.ts
+++ b/src/commands/vpn.ts
@@ -22,7 +22,7 @@ export class VpnCommand implements Command {
 				.setTitle('NordVPN')
 				.setDescription("Instructions for NordVPN")
 				.addField("Warning:", "NordVPN cannot work with Teamcraft if the Threat Protection features are active.")
-				.addField("How To:", "Open NordVPN and click the gear in the top right to open settings. On the General tab, either disable Threat Protection, or add exceptions for ffxivteamcraft.com , firebase.googleapis.com , firebaseio.com , etc.")
+				.addField("How To:", "Open NordVPN and click the gear in the top right to open settings. On the General tab, either disable Threat Protection, or add exceptions to it for ``ffxivteamcraft.com`` , ``firestore.googleapis.com`` , ``firebaseio.com`` , etc.")
 				.addField("Packet Capture:", useRawSocketBro);
 			break;
 
@@ -53,10 +53,11 @@ export class VpnCommand implements Command {
 
 		case 'openvpn':
 		case 'wireguard':
+		case 'cloudflare':
 			embed
-				.setTitle('OpenVPN and Wireguard')
+				.setTitle('OpenVPN, Wireguard, Cloudflare, etc.')
 				.setDescription("Instructions for OpenVPN and Wireguard based VPNs")
-				.addField("Warning:", "OpenVPN and Wireguard encapsulate packets, hiding them from Teamcraft. You *must* use Raw Socket mode for packet capture.")
+				.addField("Warning:", "OpenVPN, Wireguard, and other VPNs that use these as their backbone (like Cloudflare's VPN) encapsulate packets, hiding them from Teamcraft. You *must* use Raw Socket mode for packet capture.")
 				.addField("Packet Capture:", useRawSocketBro);
 			break;
 
@@ -65,8 +66,8 @@ export class VpnCommand implements Command {
 				.setTitle('VPN')
 				.setDescription("Packet Capture and Teamcraft compatibility instructions for VPN users")
 				.addField("About VPNs and Teamcraft:", "Teamcraft needs to see packets to parse them. Most VPNs hide packet contents for privacy, so Teamcraft isn't able to see them.")
-				.addField("Generic VPN Instructions:", "If your VPN is based on L2TP, it should Just Work™ in Teamcraft. If it's based on Wireguard, OpenVPN, or something more exotic you need to set Teamcraft to Raw Socket mode in settings.")
-				.addField("Specific VPN Instructions:", "We have extra help for some VPNs. You can see them by putting the VPN name after the command, such as '!!vpn mudfish'. The following list of VPNs have special instructions: ExitLag, Mudfish, Mullvad, NordVPN, OpenVPN, Wireguard.");
+				.addField("Generic VPN Instructions:", "If your VPN is based on L2TP, it should Just Work™ in Teamcraft. If it's based on Wireguard, OpenVPN, or something more exotic you need to set Teamcraft to Raw Socket mode in Settings > Desktop.")
+				.addField("Specific VPN Instructions:", "We have specific help for some VPNs. You can see them by putting the VPN name after the command, such as '!!vpn mudfish'. The following list of VPNs have specific instructions: ExitLag, Mudfish, Mullvad, NordVPN, OpenVPN, Wireguard, Cloudflare.");
 			break;
 				
 		}


### PR DESCRIPTION
- Hopefully fixed all the backslashes I recently added in commands.
- Simplified console commands to reduce confusion and cover Mac.
- Added Cloudflare to VPN file, fixed typo in URL, etc.
- Tweaked bug report template a bit for hopefully improved clarity
- Tweaked antivirus command to more strongly suggest reinstall