### PR TITLE
Reintroducing some removed commands, added more info for BitDefender,…

### DIFF
--- a/src/command_handler.ts
+++ b/src/command_handler.ts
@@ -25,6 +25,8 @@ import {ClearSiteDataCommand} from "./commands/clearsitedata";
 import {BlockedSiteCommand} from "./commands/blockedsite";
 import {BitDefenderCommand} from "./commands/bit-defender";
 import {LogsCommand} from "./commands/logs";
+import {PowershellCommand} from "./commands/powershell";
+import {VpnCommand} from "./commands/vpn";
 
 /** Handler for bot commands issued by users. */
 export class CommandHandler {
@@ -55,6 +57,8 @@ export class CommandHandler {
             AntivirusCommand,
             ClearSiteDataCommand,
             BlockedSiteCommand,
+			PowershellCommand,
+			VpnCommand,
         ];
 
         this.commands = commandClasses.map(commandClass => new commandClass());
@@ -77,7 +81,7 @@ export class CommandHandler {
             if (!matchedCommand) {
                 await reactor.failure(message);
             } else if (!allowedCommands.includes(matchedCommand)) {
-                await message.reply(`you aren't allowed to use that command. Try ${config.prefix}help.`);
+                await message.reply(`You aren't allowed to use that command. Try ${config.prefix}help.`);
                 await reactor.failure(message);
             } else {
                 await matchedCommand.run(commandContext).then(() => {

--- a/src/commands/bit-defender.ts
+++ b/src/commands/bit-defender.ts
@@ -15,14 +15,18 @@ export class BitDefenderCommand implements Command {
     async run(parsedUserCommand: CommandContext): Promise<void> {
         const embed = new EmbedBuilder()
             .setTitle("BitDefender")
-            .setDescription("Teamcraft desktop app is blocked by BitDefender")
+            .setDescription("Teamcraft desktop app is being blocked by BitDefender")
             .addFields({
-                name: "One way this can be fixed is by whitelisting `%LocalAppData%/ffxiv-teamcraft/app-X.X.X/FFXIV Teamcraft.exe`.",
-                value: "This is only temporary as the path to the exe file changes with every update, that's how Squirrel installer does it."
+                name: "One way this can be fixed is by whitelisting ``%LocalAppData%\\ffxiv-teamcraft\\app-X.X.X\\FFXIV Teamcraft.exe`` in Advanced Threat Defense, and the whole ``%LocalAppData%\\ffxiv-teamcraft\\`` folder in the main part of the antivirus.",
+                value: "The Advanced Threat Defense workaround is unfortunately only temporary, as the path to the EXE file changes with every update because of how Squirrel Installer works."
             })
-            .addFields({
-                name: "Another way to fix this is to use another antivirus, BitDefender is just lazy",
-                value: "BitDefender is triggered by Teamcraft's packet capture system because it calls win32 api to inject a dll in the game process, which makes BitDefender react immediately.\nIt doesn't check what's injected or how it's used, injection = trigger, which is just lazy."
+			.addFields({
+                name: "Another way to fix this would be to use another antivirus, as BitDefender is just lazy and this is merely one example of that.",
+                value: "BitDefender is triggered by Teamcraft's packet capture system because it calls the win32 api to inject a dll in the game process, which makes BitDefender react immediately. \n It doesn't check what's injected or how it's used -- injection = trigger -- which is overzealous and not best practices on their part."
+            })
+			.addFields({
+                name: "BitDefender may even have locked down your FFXIV config files and added firewall rules while being overzealous in its protection.",
+                value: "For the firewall rules, ensure that ``FFXIV Teamcraft.exe`` does not have any rules to block connections in your firewall. \n If your config files were locked down, perform the whitelisting mentioned above, then try to remove the potential read-only statuses from both the Teamcraft folder and ``C:\\Users\\[username]\\Documents\\My Games\\FINAL FANTASY XIV - A Realm Reborn`` by right-clicking those folders, selecting Properties, and toggling off \"Read Only\" and hitting OK. Restart your computer, then run the ``!!dirtyinstall`` process to ensure that your reinstall of Teamcraft is complete and successful. Ideally this should mean that you do not have to retrieve your game settings from any backup you may have saved to the server, but we can't fully promise this since BitDefender is short-sighted in casually locking down the files like that. (See the above point about perhaps switching to a better antivirus.)"
             })
             .setFooter({
                 text: "ffxiv-teamcraft",

--- a/src/commands/blockedsite.ts
+++ b/src/commands/blockedsite.ts
@@ -18,7 +18,7 @@ export class BlockedSiteCommand implements Command {
             .setDescription("You should ensure that there are some exceptions for Teamcraft-related hosts added to your VPN/antivirus/adblocker/security/firewall program.")
             .addFields({
                 name: "Note for Chinese users (especially):",
-                value: "Please note that Github, which is used for the automatic updater for Teamcraft, is typically blocked in China. You may configure your preferred proxy in the desktop app via Settings, Desktop, Networking to try and get around this, or you may have better luck manually downloading updates to the app from ``ffxivteamcraft.com/desktop`` via your web browser."
+                value: "Please note that Github, which is used for the automatic updater for Teamcraft, is typically blocked in China. You may configure your preferred proxy in the desktop app via Settings, Desktop, Networking to try and get around this, or you may have better luck manually downloading updates to the app from ``ffxivteamcraft.com/desktop`` via your web browser. If you are not in China or another country that routinely blocks Github, please ensure that ``github.com`` is allowed through your security software."
             })
             .addFields({
                 name: "We already have specific instructions for Kaspersky:",
@@ -29,7 +29,7 @@ export class BlockedSiteCommand implements Command {
                 value: "Type ``!!vpn generic`` in <#639503745176174592> or <#427756963867394048> to see if your VPN is among the ones for which we already have instructions."
             })
             .addFields({
-                name: "Sites you should add to any 'allow' feature your secure software might have",
+                name: "Sites you should add to any 'allow' feature your security software might have",
                 value: "If the security software you're using is not listed among the options above for which we already have commands, please try adding ``ffxivteamcraft.com`` , ``firestore.googleapis.com`` , and ``*.firebaseio.com`` to the allowed list for your VPN/antivirus/adblocker/security software/firewall. \nThere are many different types of software a user could have installed that might be blocking these sites and not a lot of troubleshooters, so please attempt to look up instructions for how to allow a URL *before* asking troubleshooters for help to find the feature in your software. If the feature does not seem to exist, or allowing these sites does not seem to resolve your issue, please let us know and we will continue to help you troubleshoot the problem!"
             })
             .setFooter({

--- a/src/commands/dirty.ts
+++ b/src/commands/dirty.ts
@@ -41,8 +41,8 @@ export class DirtyInstallCommand implements Command {
                     value: "Please open ``Control Panel\\Programs\\Programs and Features`` and make sure that TC is not listed. If it is please click it and click uninstall. It might fuss about the app not being able to be found. You may safely ignore this and click ok."
                 },
                 {
-                    name: "Uninstall win10pcap",
-                    value: "If you have win10pcap installed, please uninstall this before reinstalling Teamcraft or NPcap."
+                    name: "Uninstall Win10pcap",
+                    value: "If you have win10pcap installed, please uninstall this before reinstalling Teamcraft. It is extremely outdated (and Teamcraft now uses a completely different packet capture method anyway)."
                 },
                 {
                     name: "Restart Computer",

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -15,14 +15,14 @@ export class LogsCommand implements Command {
     async run(parsedUserCommand: CommandContext): Promise<void> {
         const embed = new EmbedBuilder()
             .setTitle("Logs")
-            .setDescription("Where to get each log file that can be useful for troubleshooting, the `%...%` path are meant to be used by pressing Win + R, pasting the path and pressing enter to open it in explorer.")
+            .setDescription("Where to get each log file that can be useful for troubleshooting; the ``%...%`` paths are meant to be used by pressing Win + R, pasting the path and pressing Enter to open it in Explorer.")
             .addFields({
                 name: "Teamcraft log",
-                value: "Main.log is the main log file for the Teamcraft desktop app, you can find it in `%AppData%/ffxiv-teamcraft/logs/`"
+                value: "``main.log`` is the main log file for the Teamcraft desktop app. You can find it in ``%AppData%\\ffxiv-teamcraft\\logs\\``"
             })
             .addFields({
                 name: "Deucalion Session log",
-                value: "Deucalion is the project that allows us to capture packets, its log files can be found in `%AppData%/deucalion` under the name `session-XXXXXXXXX.log`, pick the most recent one by ordering by last modified date."
+                value: "Deucalion is the project that allows us to capture packets. Its log files can be found in ``%AppData%\\deucalion`` under the name ``session-XXXXXXXXX.log``. Pick the most recent one by ordering by last modified date. It is possible that if Deucalion completely failed to even attempt to start, this folder and/or file may not be generated at all."
             })
             .setFooter({
                 text: "ffxiv-teamcraft",

--- a/src/commands/opendesktop.ts
+++ b/src/commands/opendesktop.ts
@@ -15,7 +15,7 @@ export class OpenExternalCommand implements Command {
     async run(parsedUserCommand: CommandContext): Promise<void> {
         const embed = new EmbedBuilder()
             .setTitle("How to open a link in the desktop app")
-            .setDescription("To open a link in the desktop app you simply replace ``https://teamcraft.com`` with ``teamcraft://``")
+            .setDescription("To open a link in the desktop app you may simply replace ``https://teamcraft.com`` with ``teamcraft://`` .")
             .addFields({
                 name: "Example",
                 value: "``https://ffxivteamcraft.com/teams/invite/example`` \n becomes \n``teamcraft://teams/invite/example``"

--- a/src/commands/pcap.ts
+++ b/src/commands/pcap.ts
@@ -31,7 +31,7 @@ export class PcapCommand implements Command {
                 },
                 {
                     name: "Did you exclude Teamcraft from your antivirus?",
-                    value: "Many antivirus programs are blocking Teamcraft out of an abundance of caution, type the ``!!antivirus`` command in <#639503745176174592> or <#427756963867394048> to learn more."
+                    value: "Many antivirus programs are now blocking Deucalion or the entirety of Teamcraft out of an abundance of caution; type the ``!!antivirus`` command in <#639503745176174592> or <#427756963867394048> for tips on how to exclude Teamcraft to avoid this false positive."
                 },
                 {
                     name: "If the above are true, please do the following.",

--- a/src/commands/powershell.ts
+++ b/src/commands/powershell.ts
@@ -1,0 +1,39 @@
+import {Command} from "./command";
+import {CommandContext} from "../models/command_context";
+import {EmbedBuilder} from "discord.js"
+
+export class PowershellCommand implements Command {
+    commandNames = ["powershell"];
+
+    constructor() {
+    }
+
+    getHelpMessage(commandPrefix: string): string {
+        return `Use ${commandPrefix}powershell to explain how to add Powershell to the Windows PATH variable, fixing a potential error where Deucalion cannot use tasklist as a command.`;
+    }
+
+    async run(parsedUserCommand: CommandContext): Promise<void> {
+        const embed = new EmbedBuilder()
+        .setTitle("Your `main.log` appears to say tasklist is not recognized as a command, or there is some other reason you may need to fix Powershell")
+        .setDescription("Ensure that Powershell is added to your PATH variable")
+		.addFields([
+			{
+			name: "Update Powershell",
+			value: "First, make sure Powershell is fully updated: <https://docs.microsoft.com/en-us/powershell/scripting/windows-powershell/install/installing-windows-powershell>"
+			},
+			{
+			name: "Ensure that Powershell has been added to your PATH Variable:",
+			value: "1. Press the Windows key, search \"env\" and hit enter \n 2. Click \"Environment Variables\" in the advanced tab \n 3. Under \"**System Variables**\", locate the Path entry \n 4. Click \"New\" and paste `%SystemRoot%\\system32\\WindowsPowerShell\\v1.0` \n 5. Click OK to confirm all this work, then try reopening TC and/or reinstalling Npcap!"
+			}
+		])
+        .setFooter({
+                text: "ffxiv-teamcraft",
+                iconURL: "https://ffxivteamcraft.com/assets/logo.png"
+        })
+        .setColor("#4880b1");
+    }
+
+    hasPermissionToRun(parsedUserCommand: CommandContext): boolean {
+        return true;
+    }
+}

--- a/src/commands/vpn.ts
+++ b/src/commands/vpn.ts
@@ -1,0 +1,135 @@
+import {Command} from './command';
+import {CommandContext} from '../models/command_context';
+import {EmbedBuilder} from 'discord.js';
+
+export class VpnCommand implements Command {
+	commandNames = ['vpn'];
+
+	getHelpMessage(commandPrefix: string): string {
+		return `Use ${commandPrefix}vpn or with arguments to load specific vpn info.`;
+	}
+
+	async run(parsedUserCommand: CommandContext): Promise<void> {
+		const args = parsedUserCommand.originalMessage.content.slice(2).split(/ +/);
+		const embed = new EmbedBuilder();
+
+//		const useRawSocketBro = "In Teamcraft settings, set packet capture mode to Raw Socket."
+
+		switch(args[1].toLowerCase()) {
+		case 'nord':
+		case 'nordvpn':
+			embed
+				.setTitle('NordVPN')
+				.setDescription("Instructions for NordVPN")
+				.addFields([
+					{
+					name: "Warning:",
+					value: "NordVPN cannot work with Teamcraft if the Threat Protection features are active."
+					},
+					{
+					name: "How To:",
+					value: "Open NordVPN and click the gear in the top right to open settings. On the General tab, either disable Threat Protection, or add exceptions to it for ``ffxivteamcraft.com`` , ``firestore.googleapis.com`` , ``firebaseio.com`` , etc."
+					}
+				])
+			await parsedUserCommand.originalMessage.reply({embeds: [embed]});
+			break;
+
+		case 'mudfish':
+			embed
+				.setTitle('Mudfish')
+				.setDescription("Instructions for Mudfish")
+				.addFields([
+					{
+					name: "Warning:",
+					value: "While Mudfish works just fine with Linux or MacOS, Windows users will need additional configuration. Teamcraft will not work with the WFP feature enabled."
+					},
+					{
+					name: "How To:",
+					value: "Open Mudfish and navigate to Settings->Programs. The WFP feature should be disabled."
+					}
+				])
+			await parsedUserCommand.originalMessage.reply({embeds: [embed]});
+			break;
+
+/*		case 'exitlag':
+			embed
+				.setTitle('ExitLag')
+				.setDescription("Instructions for ExitLag")
+				.addFields([
+					{
+					name: "Warning:",
+					value: "ExitLag sux."
+					},
+					{
+					name: "Packet Capture:",
+					value: useRawSocketBro
+					},
+			break;
+*/
+		case 'mullvad':
+			embed
+				.setTitle('Mullvad')
+				.setDescription("Instructions for Mullvad")
+				.addFields([
+					{
+					name: "Warning:",
+					value: "Mullvad's AdBlocker feature will break the connection to the Teamcraft database."
+					},
+					{
+					name: "How To:",
+					value: "Open Mullvad and disable the ad blocking feature. Mullvad's website has good alternatives that won't break Teamcraft."
+					}
+				])
+			await parsedUserCommand.originalMessage.reply({embeds: [embed]});
+			break;
+/*
+		case 'openvpn':
+		case 'wireguard':
+		case 'cloudflare':
+			embed
+				.setTitle('OpenVPN, Wireguard, Cloudflare, etc.')
+				.setDescription("Instructions for OpenVPN and Wireguard based VPNs")
+				.addFields([
+					{
+					name: "Warning:",
+					value: "OpenVPN, Wireguard, and other VPNs that use these as their backbone (like Cloudflare's VPN) encapsulate packets, hiding them from Teamcraft. You *must* use Raw Socket mode for packet capture."
+					},
+					{
+					name: "Packet Capture:",
+					value: useRawSocketBro
+					},
+			break;
+*/
+		default:
+			embed
+				.setTitle('VPN')
+				.setDescription("Packet Capture and Teamcraft compatibility instructions for VPN users")
+				.addFields([
+					{
+					name: "About VPNs and Teamcraft:",
+					value: "Teamcraft needs to see packets to parse them. Many VPNs hide packet contents for privacy, so Teamcraft may not be able to see them."
+					},
+					{
+					name: "Specific VPN Instructions:",
+					value: "We have specific help for some VPNs/security software. You can see them by putting the VPN name after the command, such as '!!vpn nordvpn'. The following list of VPNs have specific instructions: Mudfish, Mullvad, NordVPN."
+					},
+					{
+					name: "Generic VPN Instructions:",
+					value: "If your VPN is based on L2TP, it should Just Work™ in Teamcraft. If you believe it's possible your VPN or security software may be blocking vital URLs, please type ``!!blockedsite`` in <#639503745176174592> or <#427756963867394048> and try to make exceptions for those sites in your VPN."
+					}
+				])
+			.setFooter({
+            text: "ffxiv-teamcraft",
+            iconURL: "https://ffxivteamcraft.com/assets/logo.png"
+			})
+			.setColor("#4880b1");
+			break;
+		}
+
+		await parsedUserCommand.originalMessage.channel.send({embeds: [embed]});
+	}
+
+	hasPermissionToRun(_: CommandContext): boolean {
+		return true;
+	}
+}


### PR DESCRIPTION
… minor tweaks

Readded VpnCommand and PowershellCommand with new contexts to match how they can actually impact TC post-Deucalion. Left the framework for currently unnecessary commands in case we need to add new info for the other VPNs later. Added the info about locked down config files to the BitDefender command. Slightly modified a few other commands for clarity and keeping them up to date.